### PR TITLE
Added a dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Script to generate Let's Encrypt certs and add them to ISPConfig via API
 
 1. Get Let's Encrypt - follow instructions here: https://letsencrypt.readthedocs.org/en/latest/using.html
 2. Get the le2ispc script (just single script or clone whole repository)
-3. Make the le2ispc script execuatable
+3. Make the le2ispc script executable
 4. Optionally: You can copy it to a directory in $$PATH, e.g. /usr/bin
 5. In ISPC add a remote user that can at least access the "Site Domain Functions"
 6. Edit the header section of the le2ispc script - it's important to give a valid email address

--- a/le2ispc
+++ b/le2ispc
@@ -127,7 +127,7 @@ if($domainInfo['redirect_type'] == "L") {
     $webroot .= $domainInfo['redirect_path'];
 }
 
-$command = "$letsencrypt --text --agree-tos --agree-dev-preview --renew-by-default --rsa-key-size 4096 --email '$email' $domains -a webroot --webroot-path " . $webroot . " certonly";
+$command = "$letsencrypt --text --agree-tos --renew-by-default --rsa-key-size 4096 --email '$email' $domains -a webroot --webroot-path " . $webroot . " certonly";
 
 if ($dry_run) {
     echo $command;

--- a/le2ispc
+++ b/le2ispc
@@ -28,18 +28,28 @@ $forceSSL               = "y";
 # Include ISPConfig config file for DB connection
 require_once('/usr/local/ispconfig/server/lib/config.inc.php');
 
-# Check valid call
-$USAGE = "Usage: $argv[0] domain.tld [sub.domain.tld ...]";
+# Get program name
+$prog = array_shift($argv);
 
-if (count($argv) < 2) {
+# Check valid call
+$USAGE = "Usage: $prog [-n|--dry-run] domain.tld [sub.domain.tld ...]\n";
+
+if (count($argv) < 1) {
     echo $USAGE;
     exit(1);
 }	
 
+# Get first arg
+$dry_run = false;
+$arg = array_shift($argv);
+if($arg == '-n' || $arg == '--dry-run') {
+    $dry_run = true;
+    $arg = array_shift($argv);
+}
+
 # Get the domain
 echo "1. Get the domain name.\n";
-array_shift($argv);
-$domain = array_shift($argv);
+$domain = $arg;
 $subdomains = $argv;
 
 # Query the MySQL DB Directly whether $domain is a vhost
@@ -117,11 +127,14 @@ if($domainInfo['redirect_type'] == "L") {
     $webroot .= $domainInfo['redirect_path'];
 }
 
-if(!isset($beta)) {
-	$beta = "";
-}	
-
 $command = "$letsencrypt --text --agree-tos --agree-dev-preview --renew-by-default --rsa-key-size 4096 --email '$email' $domains -a webroot --webroot-path " . $webroot . " certonly";
+
+if ($dry_run) {
+    echo $command;
+    echo "\nNothing executed (dry-run)\n";
+    exit;
+}
+
 $output = shell_exec($command);
 
 if (strpos($output, 'Congratulations') === false) {

--- a/le2ispc
+++ b/le2ispc
@@ -18,8 +18,6 @@ $email                  = "user@domain.tld";
 # Force Apache/Nginx to rewrite non-ssl to ssl
 $forceSSL               = "y";
 
-# Server - uncomment if you're in beta
-#$beta                   = "--server https://acme-v01.api.letsencrypt.org/directory";
 
 /**************************************************************************************************************
 *                                                                                                             *
@@ -123,7 +121,7 @@ if(!isset($beta)) {
 	$beta = "";
 }	
 
-$command = "$letsencrypt --agree-dev-preview $beta --renew-by-default --rsa-key-size 4096 -m '$email' $domains -a webroot --webroot-path " . $webroot . " certonly";
+$command = "$letsencrypt --text --agree-tos --agree-dev-preview --renew-by-default --rsa-key-size 4096 --email '$email' $domains -a webroot --webroot-path " . $webroot . " certonly";
 $output = shell_exec($command);
 
 if (strpos($output, 'Congratulations') === false) {


### PR DESCRIPTION
You can now specify -n or --dry-run to just print the letsencrypt-auto command without executing it. This can be used to avoid running into rate limitations.