### PR TITLE
Compatibility with apache 2.2

### DIFF
--- a/le2ispc
+++ b/le2ispc
@@ -108,7 +108,7 @@ echo "3. Prepare Server for webroot authentication.\n";
 # https://letsencrypt.readthedocs.org/en/latest/api/plugins/webroot.html?highlight=webroot#module-letsencrypt.plugins.webroot
 if ( $server['type'] == 'apache' ) {
     $confFile='/etc/apache2/conf-available/letsencrypt-webroot.conf';
-    if ( ! file_exists($confFile) ) {
+    if ( ! file_exists($confFile) && is_dir('/etc/apache2/conf-available/') ) {
         $file = fopen($confFile, "w") or die("Unable to open file!");
         $txt = '
             <IfModule mod_headers.c>


### PR DESCRIPTION
In Apache 2.2, folder /etc/apache2/conf-available/ does not exists.
But there is no need of an additional conf for /.well-known/acme-challenge to be reachable via http.
So i check if this folder exists, if yes, add the wonf, if not, do not try to add the conf (an exception will be warned it tried).